### PR TITLE
fix name for line_groups in line (groups -> line_groups)

### DIFF
--- a/type.proto
+++ b/type.proto
@@ -217,7 +217,7 @@ message Line {
     optional uint32 closing_time = 19;
 
     repeated Property properties = 21;
-    repeated LineGroup groups = 23;
+    repeated LineGroup line_groups = 23;
 }
 
 message LineGroup {


### PR DESCRIPTION
Change groups to line_groups to keep consistency with naming collection the type of the object.