### PR TITLE
Navp 36

### DIFF
--- a/response.proto
+++ b/response.proto
@@ -291,6 +291,8 @@ message Metadatas {
     required string status = 4;
     repeated string contributors = 12;
     optional string timezone = 13;
+    optional string name = 14;
+    optional string last_load_at = 15;
 }
 
 message Pagination {

--- a/response.proto
+++ b/response.proto
@@ -218,6 +218,7 @@ message Status{
     optional string status = 13;
 
     optional string last_rt_data_loaded = 14;
+    optional bool is_open_data = 15;
 }
 
 message PairStopTime {

--- a/response.proto
+++ b/response.proto
@@ -292,7 +292,7 @@ message Metadatas {
     repeated string contributors = 12;
     optional string timezone = 13;
     optional string name = 14;
-    optional string last_load_at = 15;
+    optional uint64 last_load_at = 15;
 }
 
 message Pagination {


### PR DESCRIPTION
- is_open_data added in status API
- region name, last_load_at added in metadata api

- New Json for status API :
```json
{"status":
    {
    "status":"running",
    "parameters": 
    {
        ...
    }
    "is_connected_to_rabbitmq": true,
    "is_open_data": true
}
```

- New Json for metadata API :
```json
regions": [
    {
        "start_production_date": "20131007",
        "status": "running",
        "shape": "POLYGON((-2.558791 46.266838,-2.558791 48.584672,0.979875 48.584672,0.979875 46.266838,-2.558791 46.266838))",
        "id": "fr-pdl",
        "end_production_date": "20131215",
        "name": "Pays De La Loire",
        "last_load_at": "20140520T160025.494228"
    }
]
```
- Jira : http://jira.canaltp.fr/browse/NAVP-36