### PR TITLE
Add a field request_id in request

### DIFF
--- a/request.proto
+++ b/request.proto
@@ -138,7 +138,9 @@ message Request {
     optional DisruptionsRequest disruptions         = 8;
     optional CalendarsRequest calendars             = 9;
     optional PtobjectRequest pt_objects             = 10;
-    optional PlaceCodeRequest place_code        = 11;
+    optional PlaceCodeRequest place_code            = 11;
+
+    optional string request_id                      = 12;
 }
 
 


### PR DESCRIPTION
This field is used for passing the jormungandr request id to kraken, this way all log generated for a request are flagged with this id.