### PR TITLE
add experimental stuff for splitting georef and pt

### DIFF
--- a/request.proto
+++ b/request.proto
@@ -76,7 +76,7 @@ message JourneysRequest {
     optional StreetNetworkParams streetnetwork_params   = 8;
     optional bool wheelchair                            = 9      [default=false];
     optional bool show_codes                            = 11;
-    optional bool details                               = 13;
+    optional bool details                               = 13; //to be removed
     optional RTLevel realtime_level                     = 14;
     optional int32 max_extra_second_pass                = 15     [default=0];
     optional int32 walking_transfer_penalty             = 16     [default=120];
@@ -107,7 +107,7 @@ message PlaceCodeRequest {
         StopPoint = 6;
         Calendar = 7;
     }
-    required Type type= 1;
+    required Type type = 1;
     required string type_code = 2;
     required string code = 3;
 }
@@ -128,20 +128,34 @@ message PTRefRequest {
 }
 
 message Request {
-    required API requested_api                      = 1;
+    required API requested_api                           = 1;
 
-    optional PlacesRequest places                   = 2;
-    optional NextStopTimeRequest next_stop_times    = 3;
-    optional PlacesNearbyRequest places_nearby      = 4;
-    optional JourneysRequest journeys               = 5;
-    optional PTRefRequest ptref                     = 6;
-    optional PlaceUriRequest place_uri              = 7;
-    optional TrafficReportsRequest traffic_reports  = 13;
-    optional CalendarsRequest calendars             = 9;
-    optional PtobjectRequest pt_objects             = 10;
-    optional PlaceCodeRequest place_code            = 11;
+    optional PlacesRequest places                        = 2;
+    optional NextStopTimeRequest next_stop_times         = 3;
+    optional PlacesNearbyRequest places_nearby           = 4;
+    optional JourneysRequest journeys                    = 5;
+    optional PTRefRequest ptref                          = 6;
+    optional PlaceUriRequest place_uri                   = 7;
+    optional TrafficReportsRequest traffic_reports       = 13;
+    optional CalendarsRequest calendars                  = 9;
+    optional PtobjectRequest pt_objects                  = 10;
+    optional PlaceCodeRequest place_code                 = 11;
+    optional NearestStopPointsRequest nearest_stop_points = 14;
 
-    optional string request_id                      = 12;
+    optional string request_id                           = 12;
+}
+
+message NearestStopPointsRequest {
+    optional string place = 1;
+
+    optional string mode  = 2;
+    optional double walking_speed = 3;
+    optional double bike_speed = 4;
+    optional double car_speed = 5;
+    optional double bss_speed = 6;
+    optional string filter = 7;
+    optional int32 max_duration = 8;
+    optional bool reverse = 9;
 }
 
 

--- a/response.proto
+++ b/response.proto
@@ -96,7 +96,7 @@ message Fare {
 
 message Co2Emission {
     optional double value = 1;
-    optional string unit = 2;	
+    optional string unit = 2;
 }
 
 enum SectionAdditionalInformationType {
@@ -367,7 +367,7 @@ message Response{
     repeated LineGroup line_groups = 56;
     repeated Trip trips = 62;
     // For api /disruptions
-    repeated Impact impacts = 57;   
+    repeated Impact impacts = 57;
 
     //Journeys
     repeated Journey journeys = 30;
@@ -396,4 +396,12 @@ message Response{
     //Ptobject
     repeated PtObject pt_objects = 52;
     repeated FeedPublisher feed_publishers = 53;
+
+    //experimental
+    repeated NearestStopPoint nearest_stop_points = 63;
+}
+
+message NearestStopPoint{
+    optional StopPoint stop_point = 1;
+    optional int32 access_duration = 2;
 }

--- a/type.proto
+++ b/type.proto
@@ -47,6 +47,8 @@ enum API {
     PREVIOUS_DEPARTURES = 23;
     PREVIOUS_ARRIVALS = 24;
     disruptions = 25;
+    nearest_stop_points = 27;
+    pt_planner = 28;
 }
 
 enum ResponseStatus{
@@ -542,6 +544,6 @@ message PtObject {
     optional Company company = 16;
     optional VehicleJourney vehicle_journey = 17;
     optional Calendar calendar = 18;
-    optional int32 score = 19;	
+    optional int32 score = 19;
     optional Trip trip = 20;
 }


### PR DESCRIPTION
There is two new API in kraken: "NearestStopPointsRequest" that returns all stop_points accessible from a point with the associated duration.
And "PtPlanner": it's a new journey api that only handle the PT part.