### PR TITLE
Add a new API: "geo_status" providing stats on georef data

### DIFF
--- a/response.proto
+++ b/response.proto
@@ -194,6 +194,16 @@ message Planner {
     optional string after = 4;
 }
 
+message GeoStatus{
+    optional string street_network_source = 1;
+    optional int32 nb_admins = 2;
+    optional int32 nb_admins_from_cities = 3;
+    optional int32 nb_ways = 4;
+    optional int32 nb_addresses = 5;
+    optional int32 nb_poi = 6;
+    optional string poi_source = 7;
+}
+
 message Status{
     required string publication_date = 1;
     required string start_production_date = 2;
@@ -449,7 +459,8 @@ message Response{
      
      //Isochrone
      repeated GraphicalIsochrone graphical_isochrones = 68;
-     
+
+     optional GeoStatus geo_status = 69;
 }
 
 message NearestStopPoint{

--- a/type.proto
+++ b/type.proto
@@ -51,6 +51,7 @@ enum API {
     nearest_stop_points = 27;
     pt_planner = 28;
     graphical_isochrone = 29;
+    geo_status = 30;
 }
 
 enum ResponseStatus{


### PR DESCRIPTION
This PR is related to http://jira.canaltp.fr/browse/NAVITIAII-2150
The goal of this API is to provide statistics on georef data, it isn't
at destination of our users but more for the data team, it will help
them see the impacts of their update

Maybe georef_stats would be better