### PR TITLE
Network : remove lines

### DIFF
--- a/type.proto
+++ b/type.proto
@@ -484,7 +484,6 @@ message Poi {
 message Network {
     optional string uri 		= 3;
     optional string name 		= 4;
-    repeated Line lines 		= 5;
     repeated Message messages 	= 6;
     repeated string impact_uris = 22;
     repeated Code codes         = 7;


### PR DESCRIPTION
The field 'lines' isn't used anymore in any requests. It is now removed as it is useless.