### PR TITLE
Add a deadline to every request made

### DIFF
--- a/request.proto
+++ b/request.proto
@@ -213,6 +213,11 @@ message Request {
     optional string request_id                           = 12;
     optional bool disable_feedpublisher                  = 22;
     optional bool disable_disruption                     = 25 [default=false];
+
+    //after this date the request should be ignored as the caller will have timeout
+    //the format of the date is: 20190101T120102,32910
+    //a string is used to be able to store milliseconds
+    optional string deadline                             = 26;
 }
 
 message NearestStopPointsRequest {

--- a/request.proto
+++ b/request.proto
@@ -214,7 +214,7 @@ message Request {
     optional bool disable_feedpublisher                  = 22;
     optional bool disable_disruption                     = 25 [default=false];
 
-    //after this date the request should be ignored as the caller will have timeout
+    //after this date the request should be ignored as the caller will have timeouted
     //the format of the date is: 20190101T120102,32910
     //a string is used to be able to store milliseconds
     optional string deadline                             = 26;

--- a/response.proto
+++ b/response.proto
@@ -411,6 +411,7 @@ message Error{
         service_unavailable = 11;
         invalid_protobuf_request = 12;
         internal_error = 13;
+        deadline_expired = 14;
     }
     optional error_id id = 1;
     optional string message = 2;


### PR DESCRIPTION
This allow to ignore request that have already timeout.
Using a string for the datetime isn't pretty nor what we do usually, but
we need to keep milliseconds to handle short timeout.