### PR TITLE
add frequency informations into vj

### DIFF
--- a/type.proto
+++ b/type.proto
@@ -404,12 +404,6 @@ message StopDateTime {
     optional MessageStatus arrival_status = 9;
 }
 
-message FrequencyVehicleJourney {
-    optional uint64 start_time   = 1;
-    optional uint64 end_time     = 2;
-    optional uint64 headway_secs = 3;
-}
-
 message StopTime {
     optional uint64 arrival_time = 1; // Local arrival
     optional uint64 utc_arrival_time = 10; // UTC arrival
@@ -450,7 +444,9 @@ message VehicleJourney {
     repeated Comment comments = 27;
     repeated Code codes = 25;
     repeated Calendar calendars = 26;
-    optional FrequencyVehicleJourney frequency_vehicle_journey = 28;
+    optional uint64 start_time = 28;
+    optional uint64 end_time = 29;
+    optional uint64 headway_secs = 30;
 }
 
 message Trip {

--- a/type.proto
+++ b/type.proto
@@ -404,6 +404,11 @@ message StopDateTime {
     optional MessageStatus arrival_status = 9;
 }
 
+message FrequencyVehicleJourney {
+    optional uint64 start_time   = 1;
+    optional uint64 end_time     = 2;
+    optional uint64 headway_secs = 3;
+}
 
 message StopTime {
     optional uint64 arrival_time = 1; // Local arrival
@@ -445,6 +450,7 @@ message VehicleJourney {
     repeated Comment comments = 27;
     repeated Code codes = 25;
     repeated Calendar calendars = 26;
+    optional FrequencyVehicleJourney frequency_vehicle_journey = 28;
 }
 
 message Trip {

--- a/type.proto
+++ b/type.proto
@@ -404,6 +404,7 @@ message StopDateTime {
     optional MessageStatus arrival_status = 9;
 }
 
+
 message StopTime {
     optional uint64 arrival_time = 1; // Local arrival
     optional uint64 utc_arrival_time = 10; // UTC arrival


### PR DESCRIPTION
We want trace this frequency informations inside `/vehicle_journeys` API response.
If it is a `frequency vehicle journey`, protobuf::VehicleJourney params are exposed (_start_time, end_time, headway_secs_).

Related to GTFS Frequencies.txt params
![frequencies](https://user-images.githubusercontent.com/32099204/61366106-36823680-a889-11e9-9ee3-17efba8861a6.png)
