### PR TITLE
remove useless direction_type filed and enum

### DIFF
--- a/request.proto
+++ b/request.proto
@@ -62,7 +62,6 @@ message NextStopTimeRequest {
     optional RTLevel realtime_level       = 17;
     optional int32 items_per_schedule     = 18;
     optional bool disable_geojson         = 19;
-    optional DirectionType direction_type = 20;
 }
 
 message StreetNetworkParams {

--- a/type.proto
+++ b/type.proto
@@ -479,12 +479,6 @@ enum RTLevel {
     REALTIME = 3;
 }
 
-enum DirectionType {
-    ALL = 1;
-    FORWARD = 2;
-    BACKWARD = 3;
-}
-
 message Dataset {
     required string uri = 1;
     required Contributor contributor = 2;


### PR DESCRIPTION
Since https://github.com/CanalTP/navitia/pull/2955 was closed, there is no reason to keep direction type into protobuf.
So, we can clean it :cyclone: 