### PR TITLE
Extend path_item structure for street network maneuvers purpose

### DIFF
--- a/response.proto
+++ b/response.proto
@@ -16,6 +16,9 @@ message PathItem {
     optional int32 direction = 3;
     optional double duration = 4;
     optional CyclePathType cycle_path_type = 5;
+    optional int32 id = 6;
+    optional GeographicalCoord coordinate = 7;
+    optional string instruction = 8;
 }
 
 enum StreetNetworkMode {


### PR DESCRIPTION
**Objective**: Extend path_item structure for street network maneuvers purpose
We need some new field to be more consistent with street network **maneuvers**. **Here** use these field

_New fields_:
* id : Can be usefull for parsing
* coordinate : This coordinate is use to trigger action, like `start the voice guidance maneuver`
* instruction : the maneuver instruction like `Continue on <span class=\"next-street\">Rue des Sorins</span>. <span class=\"distance-description\">Go for <span class=\"length\">234 m</span>.</span>`

Related to :