### PR TITLE
Add RailSectionImpact type into ImpactedObject

### DIFF
--- a/request.proto
+++ b/request.proto
@@ -118,6 +118,7 @@ message JourneysRequest {
     optional uint32 timeframe_duration                  = 25; // seconds
     optional int32 depth                                = 26 [default = 1];
     optional LocationContext isochrone_center           = 27; // Needed for isochrone distributed
+    optional int32 arrival_transfer_penalty             = 28 [default=120]; // seconds
 }
 
 message PlacesNearbyRequest {

--- a/request.proto
+++ b/request.proto
@@ -118,7 +118,6 @@ message JourneysRequest {
     optional uint32 timeframe_duration                  = 25; // seconds
     optional int32 depth                                = 26 [default = 1];
     optional LocationContext isochrone_center           = 27; // Needed for isochrone distributed
-    optional int32 arrival_transfer_penalty             = 28 [default=120]; // seconds
 }
 
 message PlacesNearbyRequest {

--- a/type.proto
+++ b/type.proto
@@ -184,11 +184,17 @@ message LineSectionImpact {
     repeated Route routes                           = 3;
 }
 
+message RailSectionImpact {
+    optional PtObject from                          = 1;
+    optional PtObject to                            = 2;
+    repeated Route routes                           = 3;
+}
 
 message ImpactedObject {
-    optional PtObject pt_object                     = 1;
-    repeated StopTimeUpdate impacted_stops          = 2;
-    optional LineSectionImpact impacted_section     = 3;
+    optional PtObject pt_object                         = 1;
+    repeated StopTimeUpdate impacted_stops              = 2;
+    optional LineSectionImpact impacted_section         = 3;
+    optional RailSectionImpact impacted_rail_section    = 4;
 }
 
 message DisruptionProperty {


### PR DESCRIPTION
Same as **line_section** ->  https://github.com/CanalTP/navitia-proto/compare/add_rail_impact?expand=1#diff-8eaed4801c3a90592de7702da587b9085703592d6f0f8cd123efbac3bea02aa0R181

The _rail section_ feature PR -> https://github.com/CanalTP/navitia/pull/3447